### PR TITLE
Improve cleanup_tools function to check directory existence

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -69,7 +69,7 @@ trap cleanup_tools SIGTERM
 trap cleanup_tools EXIT
 
 cleanup_tools() {
-  rm $SILENT_WINE
+  [ -e "$SILENT_WINE" ] && rm -r "$SILENT_WINE"
 }
 
 check_tools() {


### PR DESCRIPTION
Only attempt to remove $SILENT_WINE if it exists.

fork test success:
slemke@gamesmachine:~> git clone https://github.com/srlemke/linux-simracing-utils.git
Cloning into 'linux-simracing-utils'...
remote: Enumerating objects: 94, done.
remote: Counting objects: 100% (94/94), done.
remote: Compressing objects: 100% (52/52), done.
remote: Total 94 (delta 56), reused 75 (delta 40), pack-reused 0 (from 0)
Receiving objects: 100% (94/94), 17.18 KiB | 17.18 MiB/s, done.
Resolving deltas: 100% (56/56), done.
slemke@gamesmachine:~> cd linux-simracing-utils/
slemke@gamesmachine:~/linux-simracing-utils> sh install.sh 
Install directory: /home/slemke/linux-simracing-utils
Setting up prefix at /home/slemke/linux-simracing-utils/pfx...
Prefix successfully created at /home/slemke/linux-simracing-utils/pfx
Updating registry
Registry entries updated successfully
Checking for existing .Net 4.8 install...
Installing .Net 4.8...
Successfully installed .Net 4.8
Updating prefix allfonts installation...
slemke@gamesmachine:~/linux-simracing-utils> 