### PR TITLE
Improve exit on fail and replace install of allfonts with corefonts to speedup install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -6,7 +6,7 @@ SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
 : "${UNATTENDED:="0"}"
 : "${TARGET_DIR:="$SCRIPT_DIR"}"
 
-set -euo pipefail
+set -uo pipefail
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -160,10 +160,10 @@ check_dotnet() {
   fi
 }
 
-check_allfonts() {
-  echo -e "${CYAN}Updating prefix allfonts installation...${NC}"
-  WINE=$SILENT_WINE run winetricks -q allfonts > "${LSU_LOGDIR}/allfonts_install.log" 2>&1
-  echo -e "${GREEN}Installation of allfonts is up to date.${NC}"
+check_corefonts() {
+  echo -e "${CYAN}Updating prefix corefonts installation...${NC}"
+  WINE=$SILENT_WINE run winetricks -q corefonts > "${LSU_LOGDIR}/corefonts_install.log" 2>&1
+  echo -e "${GREEN}Installation of allcore is up to date.${NC}"
 }
 
 check_prefix() {
@@ -175,7 +175,7 @@ check_prefix() {
   
   check_dotnet
 
-  check_allfonts
+  check_corefonts
 }
 
 check_simhub() {


### PR DESCRIPTION
- Continue checking error with pipe-fail but do not exit immediately on error, fixes exit when dealing with nonexistent registry entries.
- core fonts is enough to stop the UI from crashing, speeds up installation quite a bit.

fork test:

```
slemke@zink ~/linux-simracing-utils $ sh install.sh
Install directory: /home/slemke/linux-simracing-utils
Setting up prefix at /home/slemke/linux-simracing-utils/pfx...
Prefix successfully created at /home/slemke/linux-simracing-utils/pfx
Updating registry
Registry entries updated successfully
Checking for existing .Net 4.8 install...
Installing .Net 4.8...
Successfully installed .Net 4.8
Updating prefix corefonts installation...
Installation of allcore is up to date.
Checking for existing SimHub installation...
SimHub installation not found, do you want to install SimHub? [Y/n]
Installing SimHub...
SimHub successfully installed.
Checking for existing CrewChief installation...
CrewChief installation not found, do you want to install CrewChief? [Y/n]n
Skipping CrewChief installation
Checking for existing Winecarte installation...
Winecarte installation found, do you want to update Winecarte? [Y/n]
Updating Winecarte...
Winecarte successfully updated.
```