### PR TITLE
fix typo (set environment?)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -162,7 +162,9 @@ check_dotnet() {
 
 check_corefonts() {
   echo -e "${CYAN}Updating prefix corefonts installation...${NC}"
+  set +e
   WINE=$SILENT_WINE run winetricks -q corefonts > "${LSU_LOGDIR}/corefonts_install.log" 2>&1
+  set -e
   echo -e "${GREEN}Installation of corefonts is up to date.${NC}"
 }
 


### PR DESCRIPTION
i have no idea what specifically this does in bash, but doing this made the script actually run for me
pinged you in the discord mentioning it
there's also this

```
[Desktop Entry]
Name=SimHub
Exec=/home/user/git/linux-simracing-utils/bin/lsu-launch-wrapper "C:\\\\ProgramData\\\\Microsoft\\\\Windows\\\\Start\\ Menu\\\\Programs\\\\SimHub\\\\SimHub.lnk
Type=Application
StartupNotify=true
Path=/home/user/git/linux-simracing-utils/pfx/dosdevices/c:/Program Files (x86)/SimHub
Icon=E3EA_SimHubWPF.0
StartupWMClass=simhubwpf.exe
```

no idea how to fix this in the script, but i'm pretty sure there shouldn't be four backslashes 